### PR TITLE
merge r_sdk_changes

### DIFF
--- a/client-api_r/SiriusSDK.R
+++ b/client-api_r/SiriusSDK.R
@@ -50,7 +50,7 @@ SiriusSDK = R6::R6Class(
         } else if (Sys.info()['sysname']=="Windows"){
           setwd("./app")
 	  file <- Sys.glob(file.path("sirius_cli*.jar"))
-	} else if (Sys.info()['sysname']=="Darwin" {
+	} else if (Sys.info()['sysname']=="Darwin"){
 	  setwd("../app")
 	  file <- Sys.glob(file.path("sirius_cli*.jar"))
         } else {

--- a/client-api_r/SiriusSDK.R
+++ b/client-api_r/SiriusSDK.R
@@ -10,7 +10,7 @@ SiriusSDK = R6::R6Class(
     basePath = "",
     baseDirectory = "",
 
-    start = function(pathToSirius = "sirius", projectSpace = NULL, host = "http://localhost:", port = 8080, workSpace = NULL, force=FALSE){
+    start = function(pathToSirius = "sirius_from_path", projectSpace = NULL, host = "http://localhost:", port = 8080, workSpace = NULL, force=FALSE){
 
       # reset SDK params to default when failing on early stage, i.e. when providing a port as non integer
       resetSDK <- function(){
@@ -27,7 +27,7 @@ SiriusSDK = R6::R6Class(
       getVersion <- function(){
 
 	# try to get Sirius from PATH
-        if(pathToSirius == "sirius"){
+        if(pathToSirius == "sirius_from_path"){
           tryCatch({
             out <- system("sirius --version", intern=TRUE, show.output.on.console=FALSE)
             numbers <- regmatches(out[1], gregexpr("\\d+", out[1]))[[1]]
@@ -46,15 +46,19 @@ SiriusSDK = R6::R6Class(
         setwd(dirname(pathToSirius))
         if(Sys.info()['sysname']=="Linux"){
           setwd("../lib/app")
-        } else if (Sys.info()['sysname'] %in% c("Windows","Darwin")){
-          setwd("../app")
+	  file <- Sys.glob(file.path('*.jar'))
+        } else if (Sys.info()['sysname']=="Windows"){
+          setwd("./app")
+	  file <- Sys.glob(file.path("sirius_cli*.jar"))
+	} else if (Sys.info()['sysname']=="Darwin" {
+	  setwd("../app")
+	  file <- Sys.glob(file.path("sirius_cli*.jar"))
         } else {
           # reset working directory
           setwd(wd)
           resetSDK()
           stop("Unsupported operating system.")
         }
-        file <- Sys.glob(file.path('*.jar'))
         numbers <- regmatches(file, gregexpr("\\d+", file))[[1]]
         # reset working directory
         setwd(wd)

--- a/client-api_r/generated/R/SiriusSDK.R
+++ b/client-api_r/generated/R/SiriusSDK.R
@@ -25,7 +25,7 @@ SiriusSDK = R6::R6Class(
 	    
       # if Sirius is installed via sirius-ms conda package under Windows,
       # find executable and use path as pathToSirius
-      if(all(pathToSirius=="sirius-ms", Sys.info()['sysname']=="Windows"){
+      if(all(pathToSirius=="sirius-ms", Sys.info()['sysname']=="Windows")){
         tryCatch({
 	  root_dir <- file.path(Sys.getenv("USERPROFILE"), "*conda*")
 	  file_pattern <- file.path("envs", "*", "bin", "sirius.bat")

--- a/client-api_r/generated/R/SiriusSDK.R
+++ b/client-api_r/generated/R/SiriusSDK.R
@@ -22,6 +22,17 @@ SiriusSDK = R6::R6Class(
         self$basePath = ""
         self$baseDirectory = ""
       }
+	    
+      if(all(pathToSirius=="sirius-ms", Sys.info()['sysname']=="Windows"){
+        tryCatch({
+	  root_dir <- file.path(Sys.getenv("USERPROFILE"), "*conda*")
+	  file_pattern <- file.path("envs", "*", "bin", "sirius.bat")
+	  matching_file <- Sys.glob(file.path(root_dir, file_pattern))
+	  pathToSirius <- matching_file
+	}, error = function(e){
+	  resetSDK()
+	  stop("The 'sirius-ms' package seems not to be installed in any conda environment. Please install the package using 'conda install -c conda-forge sirius-ms' or provide a valid path to your own Sirius executable.")
+	}
 
       # extract the (major) version of Sirius from the .jar file
       getVersion <- function(){
@@ -31,20 +42,11 @@ SiriusSDK = R6::R6Class(
           tryCatch({
 	    if (Sys.info()['sysname'] %in% c("Linux","Darwin")){
               out <- system("sirius --version", intern=TRUE, show.output.on.console=FALSE)
-	    } else if (Sys.info()['sysname']=="Windows"){
-	      root_dir <- file.path(Sys.getenv("USERPROFILE"), "*conda*")
-	      file_pattern <- file.path("envs", "*", "bin", "sirius.bat")
-	      matching_file <- Sys.glob(file.path(root_dir, file_pattern))
-	      wd <- getwd()
-	      setwd(dirname(matching_file))
-	      out <- system("sirius.bat --version", intern=TRUE, show.output.on.console=FALSE)
-	      setwd(wd)
-	      pathToSirius <- matching_file
+	      numbers <- regmatches(out[1], gregexpr("\\d+", out[1]))[[1]]
+              return(paste(numbers[1], numbers[2], sep = "."))
 	    } else {
 	      stop("Your OS is currently not supported for automatically getting Sirius from PATH or from a sirius-ms installation. Please call start() again and specify the total path to Sirius.")
             }
-	    numbers <- regmatches(out[1], gregexpr("\\d+", out[1]))[[1]]
-            return(paste(numbers[1], numbers[2], sep = "."))
 	  },error = function(e){
             resetSDK()
             stop("Could not find Sirius in PATH. The 'sirius-ms' package seems not to be installed in this environment. Please install the package using 'conda install -c conda-forge sirius-ms' or privide a valid path to your own Sirius executable.")

--- a/client-api_r/generated/R/SiriusSDK.R
+++ b/client-api_r/generated/R/SiriusSDK.R
@@ -10,7 +10,7 @@ SiriusSDK = R6::R6Class(
     basePath = "",
     baseDirectory = "",
 
-    start = function(pathToSirius = "sirius_from_path", projectSpace = NULL, host = "http://localhost:", port = 8080, workSpace = NULL, force=FALSE){
+    start = function(pathToSirius = "sirius_ms", projectSpace = NULL, host = "http://localhost:", port = 8080, workSpace = NULL, force=FALSE){
 
       # reset SDK params to default when failing on early stage, i.e. when providing a port as non integer
       resetSDK <- function(){
@@ -27,18 +27,27 @@ SiriusSDK = R6::R6Class(
       getVersion <- function(){
 
 	# try to get Sirius from PATH
-        if(pathToSirius == "sirius_from_path"){
+        if(pathToSirius == "sirius_ms"){
           tryCatch({
-            out <- system("sirius --version", intern=TRUE, show.output.on.console=FALSE)
-            numbers <- regmatches(out[1], gregexpr("\\d+", out[1]))[[1]]
+	    if (Sys.info()['sysname'] %in% c("Linux","Darwin")){
+              out <- system("sirius --version", intern=TRUE, show.output.on.console=FALSE)
+	    } else if (Sys.info()['sysname']=="Windows"){
+	      root_dir <- file.path(Sys.getenv("USERPROFILE"), "*conda*")
+	      file_pattern <- file.path("envs", "*", "bin", "sirius.bat")
+	      matching_file <- Sys.glob(file.path(root_dir, file_pattern))
+	      wd <- getwd()
+	      setwd(dirname(matching_file))
+	      out <- system("sirius.bat --version", intern=TRUE, show.output.on.console=FALSE)
+	      setwd(wd)
+	    } else {
+	      stop("Your OS is currently not supported for automatically getting Sirius from PATH or from a sirius-ms installation. Please call start() again and specify the total path to Sirius.")
+            }
+	    numbers <- regmatches(out[1], gregexpr("\\d+", out[1]))[[1]]
             return(paste(numbers[1], numbers[2], sep = "."))
-          },error = function(e){
+	  },error = function(e){
             resetSDK()
             stop("Could not find Sirius in PATH. The 'sirius-ms' package seems not to be installed in this environment. Please install the package using 'conda install -c conda-forge sirius-ms' or privide a valid path to your own Sirius executable.")
           })
-          out <- system("sirius --version", intern=TRUE, show.output.on.console=FALSE)
-          numbers <- regmatches(out[1], gregexpr("\\d+", out[1]))[[1]]
-          return(paste(numbers[1], numbers[2], sep = "."))
         }
 
 	# get Sirius from given directory

--- a/client-api_r/generated/R/SiriusSDK.R
+++ b/client-api_r/generated/R/SiriusSDK.R
@@ -10,7 +10,7 @@ SiriusSDK = R6::R6Class(
     basePath = "",
     baseDirectory = "",
 
-    start = function(pathToSirius = "sirius_ms", projectSpace = NULL, host = "http://localhost:", port = 8080, workSpace = NULL, force=FALSE){
+    start = function(pathToSirius = "sirius-ms", projectSpace = NULL, host = "http://localhost:", port = 8080, workSpace = NULL, force=FALSE){
 
       # reset SDK params to default when failing on early stage, i.e. when providing a port as non integer
       resetSDK <- function(){
@@ -27,7 +27,7 @@ SiriusSDK = R6::R6Class(
       getVersion <- function(){
 
 	# try to get Sirius from PATH
-        if(pathToSirius == "sirius_ms"){
+        if(pathToSirius == "sirius-ms"){
           tryCatch({
 	    if (Sys.info()['sysname'] %in% c("Linux","Darwin")){
               out <- system("sirius --version", intern=TRUE, show.output.on.console=FALSE)
@@ -39,6 +39,7 @@ SiriusSDK = R6::R6Class(
 	      setwd(dirname(matching_file))
 	      out <- system("sirius.bat --version", intern=TRUE, show.output.on.console=FALSE)
 	      setwd(wd)
+	      pathToSirius <- matching_file
 	    } else {
 	      stop("Your OS is currently not supported for automatically getting Sirius from PATH or from a sirius-ms installation. Please call start() again and specify the total path to Sirius.")
             }
@@ -136,10 +137,10 @@ SiriusSDK = R6::R6Class(
 
 
       if(all(is.character(pathToSirius),length(pathToSirius) == 1)){
-        if(all(file.exists(pathToSirius),!dir.exists(pathToSirius)) || pathToSirius == "sirius"){
+        if(all(file.exists(pathToSirius),!dir.exists(pathToSirius)) || pathToSirius == "sirius-ms"){
           # the file which has to be executed
           sirius <- basename(pathToSirius)
-          if(!(pathToSirius == "sirius")) {
+          if(!(pathToSirius == "sirius-ms")) {
             sirius_call <- paste("./",sirius, sep = "")
           } else {
             sirius_call <- paste(sirius, sep = "")

--- a/client-api_r/generated/R/SiriusSDK.R
+++ b/client-api_r/generated/R/SiriusSDK.R
@@ -10,7 +10,7 @@ SiriusSDK = R6::R6Class(
     basePath = "",
     baseDirectory = "",
 
-    start = function(pathToSirius = "sirius", projectSpace = NULL, host = "http://localhost:", port = 8080, workSpace = NULL, force=FALSE){
+    start = function(pathToSirius = "sirius_from_path", projectSpace = NULL, host = "http://localhost:", port = 8080, workSpace = NULL, force=FALSE){
 
       # reset SDK params to default when failing on early stage, i.e. when providing a port as non integer
       resetSDK <- function(){
@@ -27,7 +27,7 @@ SiriusSDK = R6::R6Class(
       getVersion <- function(){
 
 	# try to get Sirius from PATH
-        if(pathToSirius == "sirius"){
+        if(pathToSirius == "sirius_from_path"){
           tryCatch({
             out <- system("sirius --version", intern=TRUE, show.output.on.console=FALSE)
             numbers <- regmatches(out[1], gregexpr("\\d+", out[1]))[[1]]
@@ -46,15 +46,19 @@ SiriusSDK = R6::R6Class(
         setwd(dirname(pathToSirius))
         if(Sys.info()['sysname']=="Linux"){
           setwd("../lib/app")
-        } else if (Sys.info()['sysname'] %in% c("Windows","Darwin")){
-          setwd("../app")
+	  file <- Sys.glob(file.path('*.jar'))
+        } else if (Sys.info()['sysname']=="Windows"){
+          setwd("./app")
+	  file <- Sys.glob(file.path("sirius_cli*.jar"))
+	} else if (Sys.info()['sysname']=="Darwin"){
+	  setwd("../app")
+	  file <- Sys.glob(file.path("sirius_cli*.jar"))
         } else {
           # reset working directory
           setwd(wd)
           resetSDK()
           stop("Unsupported operating system.")
         }
-        file <- Sys.glob(file.path('*.jar'))
         numbers <- regmatches(file, gregexpr("\\d+", file))[[1]]
         # reset working directory
         setwd(wd)

--- a/client-api_r/generated/R/SiriusSDK.R
+++ b/client-api_r/generated/R/SiriusSDK.R
@@ -58,7 +58,7 @@ SiriusSDK = R6::R6Class(
 	# get Sirius from given directory
         wd <- getwd()
         setwd(dirname(pathToSirius))
-        if(Sys.info()['sysname'] %in% ("Linux", "Darwin")){
+        if(Sys.info()['sysname'] %in% c("Linux","Darwin")){
           out <- system("sirius --version", intern=TRUE, show.output.on.console=FALSE)
 	} else if (Sys.info()['sysname'] == "Windows"){
 	  out <- system("sirius.bat --version", intern=TRUE, show.output.on.console=FALSE)

--- a/client-api_r/generated/R/SiriusSDK.R
+++ b/client-api_r/generated/R/SiriusSDK.R
@@ -51,14 +51,14 @@ SiriusSDK = R6::R6Class(
           setwd("./app")
 	  file <- Sys.glob(file.path("sirius_cli*.jar"))
 	  # service versions have different files in app
-	  if (!file.exists(file)) {
+	  if (length(file)==0) {
 	    file <- Sys.glob(file.path("sirius_rest_service*.jar"))
 	  }
 	} else if (Sys.info()['sysname']=="Darwin"){
 	  setwd("../app")
 	  file <- Sys.glob(file.path("sirius_cli*.jar"))
 	  # service versions have different files in app
-	  if (!file.exists(file)) {
+	  if (length(file)==0) {
 	    file <- Sys.glob(file.path("sirius_rest_service*.jar"))
 	  }
         } else {

--- a/client-api_r/generated/R/SiriusSDK.R
+++ b/client-api_r/generated/R/SiriusSDK.R
@@ -50,9 +50,17 @@ SiriusSDK = R6::R6Class(
         } else if (Sys.info()['sysname']=="Windows"){
           setwd("./app")
 	  file <- Sys.glob(file.path("sirius_cli*.jar"))
+	  # service versions have different files in app
+	  if (!file.exists(file)) {
+	    file <- Sys.glob(file.path("sirius_rest_service*.jar"))
+	  }
 	} else if (Sys.info()['sysname']=="Darwin"){
 	  setwd("../app")
 	  file <- Sys.glob(file.path("sirius_cli*.jar"))
+	  # service versions have different files in app
+	  if (!file.exists(file)) {
+	    file <- Sys.glob(file.path("sirius_rest_service*.jar"))
+	  }
         } else {
           # reset working directory
           setwd(wd)

--- a/client-api_r/generated/R/SiriusSDK.R
+++ b/client-api_r/generated/R/SiriusSDK.R
@@ -92,9 +92,9 @@ SiriusSDK = R6::R6Class(
           self$portFile <- paste(workSpace_path,"/.sirius-",sirius_version,"/sirius.port",sep = "")
         } else {
           if(Sys.info()['sysname']=="Windows"){
-            home_path = "%HOMEPATH%"
+            home_path = Sys.getenv("USERPROFILE")
           } else if (Sys.info()['sysname'] %in% c("Linux","Darwin")){
-            home_path = "~"
+            home_path = Sys.getenv("HOME")
           } else {
             resetSDK()
             stop("Unsupported operating system.")

--- a/client-api_r/generated/R/SiriusSDK.R
+++ b/client-api_r/generated/R/SiriusSDK.R
@@ -35,6 +35,7 @@ SiriusSDK = R6::R6Class(
 	  resetSDK()
 	  stop("The 'sirius-ms' package seems not to be installed in any conda environment. Please install the package using 'conda install -c conda-forge sirius-ms' or provide a valid path to your own Sirius executable.")
 	})
+      }
 
       # extract the (major) version of Sirius from the .jar file
       getVersion <- function(){


### PR DESCRIPTION
- fixes problems arising from not having Sirius in PATH under Windows when installed with Condas sirius-ms
- improves reading out the version number from sirius (now file-independent)
- fixes paths to sirius.pid and sirius.port files under Windows